### PR TITLE
Publish handle state accessor

### DIFF
--- a/lib/portlayer/exec/base.go
+++ b/lib/portlayer/exec/base.go
@@ -156,6 +156,64 @@ func (c *containerBase) updates(op trace.Operation) (*containerBase, error) {
 	return base, nil
 }
 
+// determine if the containerVM has started - this could pick up stale data in the started field for an out-of-band
+// power change such as HA or user intervention where we have not had an opportunity to reset the entry.
+func (c *containerBase) cleanStart(op trace.Operation) bool {
+	if len(c.ExecConfig.Sessions) == 0 {
+		op.Warnf("Container %c has no sessions stored in in-memory config", c.ExecConfig.ID)
+		return true
+	}
+
+	for _, session := range c.ExecConfig.Sessions {
+		if session.Started != "true" {
+			return false
+		}
+	}
+	return true
+}
+
+// determine if the containerVM has ever been started - we use the session started time for this as we have no
+// cVM global record to indicate the fact.
+func (c *containerBase) hasStarted(op trace.Operation) bool {
+	if len(c.ExecConfig.Sessions) == 0 {
+		op.Warnf("Container %c has no sessions stored in in-memory config", c.ExecConfig.ID)
+		return true
+	}
+
+	for _, session := range c.ExecConfig.Sessions {
+		if session.Detail.StartTime != 0 || session.Detail.StopTime != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// State returns the state of the containerVM based on data in the handle, with no refresh
+func (c *containerBase) State(op trace.Operation) State {
+	powerState := c.Runtime.PowerState
+	state := StateUnknown
+
+	switch powerState {
+	case types.VirtualMachinePowerStatePoweredOn:
+		if c.cleanStart(op) {
+			state = StateRunning
+		} else {
+			// could be stopping but this is a better guess and is still transient
+			state = StateStarting
+		}
+	case types.VirtualMachinePowerStatePoweredOff:
+		if c.hasStarted(op) {
+			state = StateStopped
+		} else {
+			state = StateCreated
+		}
+	case types.VirtualMachinePowerStateSuspended:
+		state = StateSuspended
+	}
+
+	return state
+}
+
 func (c *containerBase) ReloadConfig(op trace.Operation) error {
 	defer trace.End(trace.Begin(c.ExecConfig.ID, op))
 


### PR DESCRIPTION
In order to make decisions based on the consistent state view in a handle
it's necessary to have access to the _state as known by the handle_ and
not just the state at point in time of request.
This adds the necessary call and refactors some state transmution logic
out of exec.Container and into the base objects.