### PR TITLE
Report exec start errors correctly

### DIFF
--- a/pkg/vsphere/extraconfig/vmomi/optionvalue.go
+++ b/pkg/vsphere/extraconfig/vmomi/optionvalue.go
@@ -30,7 +30,7 @@ func OptionValueMap(src []types.BaseOptionValue) map[string]string {
 	for i := range src {
 		k := src[i].GetOptionValue().Key
 		v := src[i].GetOptionValue().Value.(string)
-		kv[k] = unescapeNil(v)
+		kv[k] = UnescapeNil(v)
 	}
 	return kv
 }
@@ -55,7 +55,7 @@ func OptionValueFromMap(data map[string]string, escape bool) []types.BaseOptionV
 	i := 0
 	for k, v := range data {
 		if escape {
-			v = escapeNil(v)
+			v = EscapeNil(v)
 		}
 		array[i] = &types.OptionValue{Key: k, Value: v}
 		i++
@@ -100,7 +100,7 @@ func OptionValueUpdatesFromMap(existing []types.BaseOptionValue, new map[string]
 			continue
 		} else if ok {
 			// changed
-			updates[v.Key] = escapeNil(nV)
+			updates[v.Key] = EscapeNil(nV)
 		} else {
 			// deletion
 			// NOTE: ignored as this also deletes non VIC entries currently
@@ -116,14 +116,14 @@ func OptionValueUpdatesFromMap(existing []types.BaseOptionValue, new map[string]
 		}
 
 		if _, ok := updates[k]; !ok {
-			updates[k] = escapeNil(v)
+			updates[k] = EscapeNil(v)
 		}
 	}
 
 	return OptionValueFromMap(updates, false)
 }
 
-func escapeNil(input string) string {
+func EscapeNil(input string) string {
 	if input == "" {
 		return "<nil>"
 	}
@@ -131,7 +131,7 @@ func escapeNil(input string) string {
 	return input
 }
 
-func unescapeNil(input string) string {
+func UnescapeNil(input string) string {
 	if input == "<nil>" {
 		return ""
 	}

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -309,9 +309,7 @@ func (vm *VirtualMachine) WaitForKeyChange(op trace.Operation, keys map[string]s
 
 	// fix up the filter map. value of "" ---> "<nil>"
 	for k, v := range keys {
-		if v == "" {
-			keys[k] = "<nil>"
-		}
+		keys[k] = vmomi.EscapeNil(v)
 	}
 
 	waitFunc := func(pc []types.PropertyChange) bool {


### PR DESCRIPTION
We were already waiting for the exec task to complete its launch one way
or another. This adds logic that determines whether the launch was
successful before generating the exec start event and returning.

Also uses the existing vmomi methods for escaping nils instead of special
casing it in WaitForKeyChange.