### PR TITLE
Refactor task state wait call

### DIFF
--- a/lib/config/executor/container_vm.go
+++ b/lib/config/executor/container_vm.go
@@ -234,7 +234,6 @@ type Cmd struct {
 type SessionConfig struct {
 	// The primary session may have the same ID as the executor owning it
 	Common `vic:"0.1" scope:"read-only" key:"common"`
-	Detail `vic:"0.1" scope:"read-write" key:"detail"`
 
 	// The primary process for the session
 	Cmd Cmd `vic:"0.1" scope:"read-only" key:"cmd"`
@@ -278,6 +277,10 @@ type SessionConfig struct {
 	// Need to go here since UID/GID resolution must be done on appliance
 	User  string `vic:"0.1" scope:"read-only" key:"User"`
 	Group string `vic:"0.1" scope:"read-only" key:"Group"`
+
+	// Detail contains create/started/stopped timestamps. It is placed last in the structure so that all
+	// other state serialization is complete by the time this is updated when iterating in order.
+	Detail `vic:"0.1" scope:"read-write" key:"detail"`
 }
 
 type Detail struct {

--- a/lib/portlayer/task/common.go
+++ b/lib/portlayer/task/common.go
@@ -58,6 +58,8 @@ func toggleActive(op *trace.Operation, h interface{}, id string, active bool) (i
 		return nil, TaskNotFoundError{msg: fmt.Sprintf("Cannot find task %s", id)}
 	}
 
+	// TODO: determine if a reload is required based on current state
+
 	op.Debugf("Toggling active state of task %s (%s): %t", id, task.Cmd.Path, active)
 	task.Active = active
 	handle.Reload()

--- a/lib/portlayer/task/state.go
+++ b/lib/portlayer/task/state.go
@@ -33,6 +33,7 @@ const (
 //       callers should act on power state information before calling this.
 func State(op trace.Operation, e *executor.SessionConfig) (string, error) {
 
+	// DO NOT ASSUME THAT WE CANNOT GET STATE TEARING - THE ORDERING OF SERIALIZATION IS GO REFLECT PACKAGE DEPENDENT
 	switch {
 	case e.Started == "" && e.Detail.StartTime == 0 && e.Detail.StopTime == 0:
 		return CreatedState, nil
@@ -44,6 +45,7 @@ func State(op trace.Operation, e *executor.SessionConfig) (string, error) {
 		// NOTE: this assumes that StopTime does not get set. We really need to investigate this further as it does not look like it will be the case based on the way the child reaper attempts to write things.
 		return FailedState, nil
 	default:
+		op.Debugf("task state cannot be determined (start=%s, starttime: %s, stoptime: %s)", e.Started, e.StartTime, e.StopTime)
 		return UnknownState, nil
 	}
 }


### PR DESCRIPTION
This adds a task state wait helper for exec that consolidates the common
code between waiting for a task to start and waiting for it to exit.
This also reorders the SessionConfig.Detail field to the end of the
structure so that it is the last thing serialized - we shouldn't assume
any ordering in how we get field updates from ESX/VC as the diffing that
feeds the property change listener is opaque to us, but this should help
reduce incidence of state tearing.
